### PR TITLE
Add Support for Dynamic Analytics Configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ from flask import Blueprint, Flask, render_template, url_for, request, redirect,
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
 
-from config import BASE_DIR, DATA_FOLDER, SITE_TABLES_FOLDER, RES_TABLES_FOLDER, REP_STRUCS_FOLDER, PROTS_FOLDER, ASSEMBLY_FOLDER, CIF_SIFTS_DIR, CHAIN_MAPPING_DIR, USER_JOBS_OUT_FOLDER, SESSIONS_FOLDER, SLIVKA_URL, STATIC_URL_PATH, URL_PREFIX
+from config import ANALYTICS_DOMAIN, ANALYTICS_SCRIPT_URL, BASE_DIR, DATA_FOLDER, SITE_TABLES_FOLDER, RES_TABLES_FOLDER, REP_STRUCS_FOLDER, PROTS_FOLDER, ASSEMBLY_FOLDER, CIF_SIFTS_DIR, CHAIN_MAPPING_DIR, USER_JOBS_OUT_FOLDER, SESSIONS_FOLDER, SLIVKA_URL, STATIC_URL_PATH, URL_PREFIX
 from filters import datetime_parse, datetime_format
 from forms import LigysisForm
 from logger_config import setup_logging
@@ -444,6 +444,16 @@ app.config['SESSION_COOKIE_NAME'] = 'ligysis_session'
 CORS(app, resources={rf"{URL_PREFIX}/*": {"origins": ["http://www-dev.compbio.dundee.ac.uk",
                                                       "http://www.compbio.dundee.ac.uk",
                                                       "https://www.compbio.dundee.ac.uk"]}})
+
+
+# Analytics configuration
+@app.context_processor
+def inject_config():
+    return {
+        'ANALYTICS_DOMAIN': ANALYTICS_DOMAIN,
+        'ANALYTICS_SCRIPT_URL': ANALYTICS_SCRIPT_URL
+    }
+
 
 # Use Blueprint to add URL prefix to serve site from a sub-directory
 main = Blueprint('main', __name__, url_prefix=URL_PREFIX, static_url_path=STATIC_URL_PATH, static_folder='static')

--- a/config.py
+++ b/config.py
@@ -49,3 +49,7 @@ DATABASE_PATH = os.environ.get('APP_DATABASE_PATH', DATABASE_PATH)
 
 SLIVKA_URL = os.environ.get('SLIVKA_URL', 'http://localhost:3203')
 EXPIRATION_DAYS = float(os.environ.get('APP_EXPIRATION_DAYS', 7))
+
+# Analytics configuration
+ANALYTICS_DOMAIN = os.environ.get('ANALYTICS_DOMAIN')
+ANALYTICS_SCRIPT_URL = os.environ.get('ANALYTICS_SCRIPT_URL')

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,9 @@
             window.appBaseUrl = `${protocol}//${host}/${basePath}`.replace(/\/$/, '');
             window.staticBaseUrl = `${protocol}//${host}/${basePath}/static`.replace(/\/$/, '');
         </script>
-        <script defer data-domain="compbio.dundee.ac.uk" src="https://analytics.compbio.dundee.ac.uk/js/script.js"></script>
+        {% if ANALYTICS_DOMAIN and ANALYTICS_SCRIPT_URL %}
+        <script defer data-domain="{{ ANALYTICS_DOMAIN }}" src="{{ ANALYTICS_SCRIPT_URL }}"></script>
+        {% endif %}
     </head>
     <body>
         <header style="padding-top: 0em; padding-bottom: 0em">


### PR DESCRIPTION
## **Add Support for Dynamic Analytics Configuration**

This PR introduces support for dynamic configuration of the analytics script in the `LIGYSIS-web` project. The changes allow the domain and script URL for analytics to be configured via environment variables, enabling greater flexibility and consistency across deployments. This also avoids console errors in the local development version compared to the earlier hardcoded implementation.

### **Why This Change?**

1. **Flexibility and Maintainability**
   - Decoupling analytics configuration from hardcoded values makes it easier to adapt to different environments (e.g., development, staging, production) without modifying the source code.
   - Improves maintainability and reduces potential deployment errors.

2. **Resolution of Front-End Issues**
   - The earlier approach used for other DRSASP services, which relied on injecting analytics with an Apache `Substitute` directive, failed for this application. The database search autocomplete implementation added thousands of lines to the HTML, exceeding `Substitute`'s limits and causing issues with the front-end.
   - This new approach shifts the analytics configuration to the application level, offloading work from the front-end proxy.

3. **Flexibility for System and Service Levels**
   - Although analytics now need to be configured per application, using consistent environment variable names allows system-level configuration with the flexibility to override settings at the service level.

### **Summary of Changes**

1. **`config.py`**
   - Added two new environment variables:
     - `ANALYTICS_DOMAIN`: Specifies the domain used for analytics tracking.
     - `ANALYTICS_SCRIPT_URL`: Specifies the URL for loading the analytics script.

2. **`app.py`**
   - Introduced a context processor (`inject_config`) to make `ANALYTICS_DOMAIN` and `ANALYTICS_SCRIPT_URL` available in templates.

3. **`templates/base.html`**
   - Modified the analytics `<script>` tag to dynamically load the domain and script URL from the injected configuration variables.
   - Wrapped the script tag with a conditional block to ensure analytics are only enabled if both variables are set.

4. **Environment Variables**
   - Environment variables `ANALYTICS_DOMAIN` and `ANALYTICS_SCRIPT_URL` must be set for the analytics script to load. If unset, the script will not be included in the rendered HTML.

### **Testing**

- Verified locally with and without `ANALYTICS_DOMAIN` and `ANALYTICS_SCRIPT_URL` set.
- Ensured that the analytics script is conditionally included in the HTML as expected.

### **Systemd Example Configuration**

Below is an example of how to set the environment variables in a `systemd` service configuration file:

```ini
[Service]
Environment="ANALYTICS_DOMAIN=compbio.dundee.ac.uk"
Environment="ANALYTICS_SCRIPT_URL=https://analytics.compbio.dundee.ac.uk/js/script.js"
```